### PR TITLE
Move react-native to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "author": "Johannes Lumpe <johannes@lum.pe> (https://github.com/johanneslumpe)",
   "license": "MIT",
   "dependencies": {
-    "eventemitter3": "^0.1.6",
+    "eventemitter3": "^0.1.6"
+  },
+  "peerDependencies": {
     "react-native": ">=0.3.4 <0.5.0"
   }
 }


### PR DESCRIPTION
There should only be one copy of react-native per project. Peer dependency is the right way to express that react-native-keyboardevents wants react-native to be present but doesn't pull it in itself.
