### PR TITLE
Upgrade eventemitter3 to 1.1.0

### DIFF
--- a/KeyboardEvents.ios.js
+++ b/KeyboardEvents.ios.js
@@ -2,7 +2,7 @@
 
 var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 var RNKeyboardEventsManager = require('NativeModules').RNKeyboardEventsManager;
-var EventEmitter = require('eventemitter3').EventEmitter;
+var EventEmitter = require('eventemitter3');
 
 var KeyboardEventEmitter = new EventEmitter();
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Johannes Lumpe <johannes@lum.pe> (https://github.com/johanneslumpe)",
   "license": "MIT",
   "dependencies": {
-    "eventemitter3": "^0.1.6"
+    "eventemitter3": "^1.1.0"
   },
   "peerDependencies": {
     "react-native": ">=0.3.4 <0.5.0"


### PR DESCRIPTION
Upgrading this dependency, which has mostly included bugfixes but also removed the exports.EventEmitter alias. I tested the keyboard show & hide events and the rn-keyboardevents API behaves the same.
