### PR TITLE
Rc0.6.0rc react native dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keyboardevents",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Monitors keyboard show/hide notifications",
   "main": "KeyboardEvents.ios.js",
   "scripts": {
@@ -23,6 +23,6 @@
     "eventemitter3": "^1.1.0"
   },
   "peerDependencies": {
-    "react-native": ">=0.3.4 <0.6.0"
+    "react-native": ">=0.3.4 <=0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "eventemitter3": "^1.1.0"
   },
   "peerDependencies": {
-    "react-native": ">=0.3.4 <=0.6.0"
+    "react-native": ">=0.3.4 <=0.6.0rc"
   }
 }


### PR DESCRIPTION
It seems that we can easily bump the dependency to 0.6.0rc as Emitter seems to work just fine for rc.
