### PR TITLE
Require react-native instead of reaching into its private modules

### DIFF
--- a/KeyboardEvents.ios.js
+++ b/KeyboardEvents.ios.js
@@ -1,7 +1,11 @@
 'use strict';
 
-var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
-var RNKeyboardEventsManager = require('NativeModules').RNKeyboardEventsManager;
+var {
+  DeviceEventEmitter,
+  NativeModules: {
+    RNKeyboardEventsManager,
+  },
+} = require('react-native');
 var EventEmitter = require('eventemitter3');
 
 var KeyboardEventEmitter = new EventEmitter();


### PR DESCRIPTION
The new version of the packager doesn't let you reach into the private module namespace of react-native so go through the public interface.
